### PR TITLE
Close polygon paths in writeGeometry

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,9 +133,11 @@ function writeGeometry (feature, pbf) {
       count = ring.length
     }
     pbf.writeVarint(command(1, count)) // moveto
-    for (var i = 0; i < ring.length; i++) {
+    // do not write polygon closing path as lineto
+    var lineCount = type === 3 ? ring.length - 1 : ring.length
+    for (var i = 0; i < lineCount; i++) {
       if (i === 1 && type !== 1) {
-        pbf.writeVarint(command(2, ring.length - 1)) // lineto
+        pbf.writeVarint(command(2, lineCount - 1)) // lineto
       }
       var dx = ring[i].x - x
       var dy = ring[i].y - y
@@ -143,6 +145,9 @@ function writeGeometry (feature, pbf) {
       pbf.writeVarint(zigzag(dy))
       x += dx
       y += dy
+    }
+    if (type === 3) {
+      pbf.writeVarint(command(7, 0)) // closepath
     }
   }
 }


### PR DESCRIPTION
Fixing issue in writeGeometry that leaves valid polygon geometries unclosed:
https://github.com/mapbox/vt-pbf/issues/25

Was previously encoding the polygon closing path as `lineto` command rather than `closepath`, resulting in invalid vector tiles that cause feature display issues downstream.
`tippecanoe-decode` was finding these polygons invalid with error:
`Ring does not end with closepath (ends with 2)`