### PR TITLE
Don't convert null to the string "null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function writeProperties (context, pbf) {
 
     var value = feature.properties[key]
     var type = typeof value
-    if (type !== 'string' && type !== 'boolean' && type !== 'number') {
+    if (value !== null && type !== 'string' && type !== 'boolean' && type !== 'number') {
       value = JSON.stringify(value)
     }
     var valueKey = type + ':' + value


### PR DESCRIPTION
I hope this is an acceptable change, although I don't know the complete requirements of this package, but this fix will solve https://github.com/mapbox/mapbox-gl-js/issues/8497.

I can't think of a reason it would make sense to have null as a string `"null"` because of the ambiguity it brings. Rather make it an empty string if there is a requirement for it to be a string.