### PR TITLE
Avoid publishing 4mb bench folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "3.1.1",
   "description": "Serialize mapbox vector tiles to binary protobufs in javascript.",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "scripts": {
     "test": "eslint index.js test/*.js && tap test/*.js"
   },


### PR DESCRIPTION
Ref https://packagephobia.com/result?p=vt-pbf

The package is quite big because of bench folder which is useless for end
user/developer but takes a lot of disk size.