### PR TITLE
Skip encoding null values altogether

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,11 @@ function writeProperties (context, pbf) {
   var valuecache = context.valuecache
 
   for (var key in feature.properties) {
+    var value = feature.properties[key]
+
     var keyIndex = keycache[key]
+    if (value === null) continue // don't encode null value properties
+
     if (typeof keyIndex === 'undefined') {
       keys.push(key)
       keyIndex = keys.length - 1
@@ -102,9 +106,8 @@ function writeProperties (context, pbf) {
     }
     pbf.writeVarint(keyIndex)
 
-    var value = feature.properties[key]
     var type = typeof value
-    if (value !== null && type !== 'string' && type !== 'boolean' && type !== 'number') {
+    if (type !== 'string' && type !== 'boolean' && type !== 'number') {
       value = JSON.stringify(value)
     }
     var valueKey = type + ':' + value

--- a/test/properties.js
+++ b/test/properties.js
@@ -55,7 +55,7 @@ test('property encoding', function (t) {
     var second = layer.feature(1).properties
     t.same(first.c, '{"hello":"world"}')
     t.same(first.d, '[1,2,3]')
-    t.equals(first.e, null)
+    t.equals(first.e, undefined)
     t.same(second.c, '{"goodbye":"planet"}')
     t.same(second.d, '{"hello":"world"}')
     t.end()


### PR DESCRIPTION
Closes #42. Should keep VT fully spec-compliant while avoiding the original problem of `"null"` strings not making sense.